### PR TITLE
Use mirrors.edge.kernel.org instead of ftp address

### DIFF
--- a/make-image.sh
+++ b/make-image.sh
@@ -41,8 +41,8 @@ else
 fi
 
 if [ ! -f "${RELEASE_ISO_FILENAME}" ]; then
-	wget -q "https://ftp.qubes-os.org/iso/${RELEASE_ISO_FILENAME}" -O unverified.iso
-	wget -q "https://ftp.qubes-os.org/iso/${RELEASE_ISO_FILENAME}.asc"
+	wget -q "https://mirrors.edge.kernel.org/qubes/iso/${RELEASE_ISO_FILENAME}" -O unverified.iso
+	wget -q "https://mirrors.edge.kernel.org/qubes/iso/${RELEASE_ISO_FILENAME}.asc"
 	gpgv --keyring ./qubes-release-keyring.gpg "${RELEASE_ISO_FILENAME}.asc" unverified.iso
 	mv unverified.iso "${RELEASE_ISO_FILENAME}"
 fi


### PR DESCRIPTION
I seem to get about 5-10x faster downloads from this address:
https://mirrors.edge.kernel.org/qubes/iso/

This is also where the official download page serves its ISOs from by default:
https://www.qubes-os.org/downloads/

Compared to 1MB/s with the ftp address this repo currently references:
https://ftp.qubes-os.org/iso/

